### PR TITLE
Lwmac for update

### DIFF
--- a/boards/samr21-xpro/Makefile.dep
+++ b/boards/samr21-xpro/Makefile.dep
@@ -1,5 +1,6 @@
 ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
   USEMODULE += at86rf233
+  USEMODULE += random
   USEMODULE += gnrc_lwmac
 endif
 

--- a/sys/include/net/gnrc/lwmac/hdr.h
+++ b/sys/include/net/gnrc/lwmac/hdr.h
@@ -31,7 +31,7 @@ extern "C" {
 /******************************************************************************/
 
 typedef struct {
-    uint8_t  addr[LWMAC_MAX_L2_ADDR_LEN] __attribute__ ((aligned (LWMAC_MAX_L2_ADDR_LEN)));
+    uint8_t  addr[LWMAC_MAX_L2_ADDR_LEN];// __attribute__ ((aligned (LWMAC_MAX_L2_ADDR_LEN)));
     uint8_t  len;
 } l2_addr_t;
 #define LWMAC_L2_ADDR_INIT      { {0}, 0 }

--- a/sys/include/net/gnrc/lwmac/hdr.h
+++ b/sys/include/net/gnrc/lwmac/hdr.h
@@ -68,6 +68,7 @@ typedef struct __attribute__((packed)) {
 typedef struct __attribute__((packed)) {
     lwmac_hdr_t header;
     l2_addr_t dst_addr; /**< WA is broadcast, so destination address needed */
+    uint32_t current_phase;
 } lwmac_frame_wa_t;
 
 /**

--- a/sys/include/net/gnrc/lwmac/hdr.h
+++ b/sys/include/net/gnrc/lwmac/hdr.h
@@ -59,6 +59,7 @@ typedef struct __attribute__((packed)) {
  */
 typedef struct __attribute__((packed)) {
     lwmac_hdr_t header;
+    l2_addr_t dst_addr; /**< WR is broadcast, so destination address needed */
 } lwmac_frame_wr_t;
 
 /**

--- a/sys/include/net/gnrc/lwmac/lwmac.h
+++ b/sys/include/net/gnrc/lwmac/lwmac.h
@@ -40,6 +40,10 @@ extern "C" {
 #define LWMAC_PREAMBLE_DURATION_US      ((21*LWMAC_WAKEUP_INTERVAL_US)/10)
 #endif
 
+#ifndef LWMAC_RANDOM_BEFORE_WR_US
+#define LWMAC_RANDOM_BEFORE_WR_US        (1000U)
+#endif
+
 /* Timeout to send the next WR in case no WA has been received during that
  * time. It is referenced to the beginning of both WRs, but due to internal
  * overhead, the exact spacing is slightly higher.

--- a/sys/include/net/gnrc/lwmac/lwmac.h
+++ b/sys/include/net/gnrc/lwmac/lwmac.h
@@ -37,7 +37,7 @@ extern "C" {
 
 /* The Maximum WR duration time */
 #ifndef LWMAC_PREAMBLE_DURATION_US
-#define LWMAC_PREAMBLE_DURATION_US      ((13*LWMAC_WAKEUP_INTERVAL_US)/10)
+#define LWMAC_PREAMBLE_DURATION_US      ((21*LWMAC_WAKEUP_INTERVAL_US)/10)
 #endif
 
 /* Timeout to send the next WR in case no WA has been received during that
@@ -70,7 +70,7 @@ extern "C" {
  *         implementation
  */
 #ifndef LWMAC_WR_BEFORE_PHASE_US
-#define LWMAC_WR_BEFORE_PHASE_US        (1000U)
+#define LWMAC_WR_BEFORE_PHASE_US        (1300U)
 #endif
 
 /* WR preparation overhead before it can be sent (higher with debugging output).

--- a/sys/include/net/gnrc/lwmac/lwmac.h
+++ b/sys/include/net/gnrc/lwmac/lwmac.h
@@ -70,7 +70,7 @@ extern "C" {
  *         implementation
  */
 #ifndef LWMAC_WR_BEFORE_PHASE_US
-#define LWMAC_WR_BEFORE_PHASE_US        (500U)
+#define LWMAC_WR_BEFORE_PHASE_US        (1000U)
 #endif
 
 /* WR preparation overhead before it can be sent (higher with debugging output).

--- a/sys/include/net/gnrc/lwmac/lwmac.h
+++ b/sys/include/net/gnrc/lwmac/lwmac.h
@@ -35,6 +35,11 @@ extern "C" {
 #define LWMAC_WAKEUP_INTERVAL_US        (100U * 1000)
 #endif
 
+/* The Maximum WR duration time */
+#ifndef LWMAC_PREAMBLE_DURATION_US
+#define LWMAC_PREAMBLE_DURATION_US      ((13*LWMAC_WAKEUP_INTERVAL_US)/10)
+#endif
+
 /* Timeout to send the next WR in case no WA has been received during that
  * time. It is referenced to the beginning of both WRs, but due to internal
  * overhead, the exact spacing is slightly higher.

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -280,8 +280,8 @@ bool lwmac_update(void)
             lwmac_rx_stop(&lwmac);
             /* Dispatch received packets, timing is not critical anymore */
             _dispatch(lwmac.rx.dispatch_buffer);
-            /* Go back to sleep after successful transaction */
-            lwmac_set_state(SLEEPING);
+            /* Go back to Listen after successful transaction */
+            lwmac_set_state(LISTENING);
             break;
         default:
             lwmac_rx_update(&lwmac);

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -466,6 +466,11 @@ static void _event_cb(netdev2_t* dev, netdev2_event_t event)
 			 *
 			 * TODO: transceivers might have 2 frame buffers, so make this optional
 			 */
+            if(pkt == NULL){
+                lwmac.rx_started = false;
+                break;
+            }
+
 			if(!lwmac.rx_started) {
 				LOG_WARNING("Maybe sending kicked in and frame buffer is now corrupted\n");
 				gnrc_pktbuf_release(pkt);

--- a/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
@@ -353,7 +353,10 @@ int _parse_packet(gnrc_pktsnip_t* pkt, lwmac_packet_info_t* info)
     if(lwmac_hdr->type == FRAMETYPE_WA) {
         /* WA is broadcast, so get dst address out of header instead of netif */
         info->dst_addr = ((lwmac_frame_wa_t*)lwmac_hdr)->dst_addr;
-    } else {
+    }else if(lwmac_hdr->type == FRAMETYPE_WR){
+        /* WR is broadcast, so get dst address out of header instead of netif */
+        info->dst_addr = ((lwmac_frame_wr_t*)lwmac_hdr)->dst_addr;
+    }else {
         if(netif_hdr->dst_l2addr_len) {
             info->dst_addr.len = netif_hdr->dst_l2addr_len;
             memcpy(info->dst_addr.addr,

--- a/sys/net/gnrc/link_layer/lwmac/rx_state_machine.c
+++ b/sys/net/gnrc/link_layer/lwmac/rx_state_machine.c
@@ -172,6 +172,7 @@ static bool _lwmac_rx_update(lwmac_t* lwmac)
         lwmac_frame_wa_t lwmac_hdr;
         lwmac_hdr.header.type = FRAMETYPE_WA;
         lwmac_hdr.dst_addr = lwmac->rx.l2_addr;
+        lwmac_hdr.current_phase = _phase_now();
 
         pkt = gnrc_pktbuf_add(NULL, &lwmac_hdr, sizeof(lwmac_hdr), GNRC_NETTYPE_LWMAC);
         if(pkt == NULL) {

--- a/sys/net/gnrc/link_layer/lwmac/rx_state_machine.c
+++ b/sys/net/gnrc/link_layer/lwmac/rx_state_machine.c
@@ -162,6 +162,12 @@ static bool _lwmac_rx_update(lwmac_t* lwmac)
 
         assert(lwmac->rx.l2_addr.len != 0);
 
+        /* if found ongoing transmission,
+         * quit sending WA for collision avoidance. */
+        if(_get_netdev_state(lwmac) == NETOPT_STATE_RX){
+            GOTO_RX_STATE(RX_STATE_FAILED, true);
+        }
+
         /* Assemble WA packet */
         lwmac_frame_wa_t lwmac_hdr;
         lwmac_hdr.header.type = FRAMETYPE_WA;

--- a/sys/net/gnrc/link_layer/lwmac/rx_state_machine.c
+++ b/sys/net/gnrc/link_layer/lwmac/rx_state_machine.c
@@ -157,6 +157,7 @@ static bool _lwmac_rx_update(lwmac_t* lwmac)
         LOG_DEBUG("RX_STATE_SEND_WA\n");
 
         gnrc_pktsnip_t* pkt;
+        gnrc_pktsnip_t* pkt_lwmac;
         gnrc_netif_hdr_t* nethdr_wa;
 
         assert(lwmac->rx.l2_addr.len != 0);
@@ -171,10 +172,12 @@ static bool _lwmac_rx_update(lwmac_t* lwmac)
             LOG_ERROR("Cannot allocate pktbuf of type GNRC_NETTYPE_LWMAC\n");
             GOTO_RX_STATE(RX_STATE_FAILED, true);
         }
+        pkt_lwmac = pkt;
 
         pkt = gnrc_pktbuf_add(pkt, NULL, sizeof(gnrc_netif_hdr_t) + lwmac->rx.l2_addr.len, GNRC_NETTYPE_NETIF);
         if(pkt == NULL) {
             LOG_ERROR("Cannot allocate pktbuf of type GNRC_NETTYPE_NETIF\n");
+            gnrc_pktbuf_release(pkt_lwmac);
             GOTO_RX_STATE(RX_STATE_FAILED, true);
         }
 
@@ -206,7 +209,14 @@ static bool _lwmac_rx_update(lwmac_t* lwmac)
 //        }
 
         /* Send WA */
-		lwmac->netdev->send(lwmac->netdev, pkt);
+		int res = lwmac->netdev->send(lwmac->netdev, pkt);
+		if(res < 0){
+            LOG_ERROR("Send WA failed.");
+            if(pkt != NULL){
+                gnrc_pktbuf_release(pkt);
+            }
+            GOTO_RX_STATE(RX_STATE_FAILED, true);
+        }
         _set_netdev_state(lwmac, NETOPT_STATE_TX);
 
         /* Enable Auto ACK again for data reception */

--- a/sys/net/gnrc/link_layer/lwmac/tx_state_machine.c
+++ b/sys/net/gnrc/link_layer/lwmac/tx_state_machine.c
@@ -296,6 +296,13 @@ static bool _lwmac_tx_update(lwmac_t* lwmac)
             break;
         }
 
+        if(lwmac->tx_feedback == TX_FEEDBACK_BUSY) {
+            _queue_tx_packet(lwmac, lwmac->tx.packet);
+            lwmac->tx.packet = NULL;
+            GOTO_TX_STATE(TX_STATE_FAILED, true);
+            break;
+        }
+
         if(lwmac->tx.wr_sent == 0) {
             lwmac_set_timeout(lwmac, TIMEOUT_NO_RESPONSE, LWMAC_PREAMBLE_DURATION_US);
             /* Only the first WR use CSMA */

--- a/sys/net/gnrc/link_layer/lwmac/tx_state_machine.c
+++ b/sys/net/gnrc/link_layer/lwmac/tx_state_machine.c
@@ -140,12 +140,20 @@ static bool _lwmac_tx_update(lwmac_t* lwmac)
             LOG_INFO("Initialize broadcasting\n");
             lwmac_set_timeout(lwmac, TIMEOUT_BROADCAST_END, LWMAC_BROADCAST_DURATION_US);
 
+            gnrc_pktsnip_t* pkt_payload;
+
             /* Prepare packet with LwMAC header*/
             lwmac_frame_broadcast_t hdr = {};
             hdr.header.type = FRAMETYPE_BROADCAST;
             hdr.seq_nr = lwmac->tx.bcast_seqnr++;
 
+            pkt_payload = pkt->next;
             pkt->next = gnrc_pktbuf_add(pkt->next, &hdr, sizeof(hdr), GNRC_NETTYPE_LWMAC);
+            if(pkt->next == NULL) {
+                LOG_ERROR("Cannot allocate pktbuf of type FRAMETYPE_BROADCAST\n");
+                lwmac->tx.packet->next = pkt_payload;
+                GOTO_TX_STATE(TX_STATE_FAILED, true);
+            }
 
             /* No Auto-ACK for broadcast packets */
             netopt_enable_t autoack = NETOPT_DISABLE;
@@ -159,7 +167,11 @@ static bool _lwmac_tx_update(lwmac_t* lwmac)
             /* Don't let the packet be released yet, we want to send it again */
             gnrc_pktbuf_hold(pkt, 1);
 
-			lwmac->netdev->send(lwmac->netdev, pkt);
+            int res = lwmac->netdev->send(lwmac->netdev, pkt);
+            if(res < 0){
+                LOG_ERROR("Send broadcast pkt failed.");
+                GOTO_TX_STATE(TX_STATE_FAILED, true);
+            }
             _set_netdev_state(lwmac, NETOPT_STATE_TX);
 
             lwmac_set_timeout(lwmac, TIMEOUT_NEXT_BROADCAST, LWMAC_TIME_BETWEEN_BROADCAST_US);
@@ -173,6 +185,7 @@ static bool _lwmac_tx_update(lwmac_t* lwmac)
         LOG_DEBUG("TX_STATE_SEND_WR\n");
 
         gnrc_pktsnip_t* pkt;
+        gnrc_pktsnip_t* pkt_lwmac;
         gnrc_netif_hdr_t *nethdr;
         uint8_t* dst_addr = NULL;
         int addr_len;
@@ -194,9 +207,13 @@ static bool _lwmac_tx_update(lwmac_t* lwmac)
             GOTO_TX_STATE(TX_STATE_FAILED, true);
         }
 
+        /* track the location of this lwmac_frame_wr_t header */
+        pkt_lwmac = pkt;
+
         pkt = gnrc_pktbuf_add(pkt, NULL, sizeof(gnrc_netif_hdr_t) + addr_len, GNRC_NETTYPE_NETIF);
         if(pkt == NULL) {
             LOG_ERROR("Cannot allocate pktbuf of type GNRC_NETTYPE_NETIF\n");
+            gnrc_pktbuf_release(pkt_lwmac);
             GOTO_TX_STATE(TX_STATE_FAILED, true);
         }
 
@@ -214,7 +231,14 @@ static bool _lwmac_tx_update(lwmac_t* lwmac)
 
         /* Prepare WR, this will discard any frame in the transceiver that has
          * possibly arrived in the meantime but we don't care at this point. */
-		lwmac->netdev->send(lwmac->netdev, pkt);
+        int res = lwmac->netdev->send(lwmac->netdev, pkt);
+        if(res < 0){
+            LOG_ERROR("Send WR failed.");
+            if(pkt != NULL){
+                gnrc_pktbuf_release(pkt);
+            }
+            GOTO_TX_STATE(TX_STATE_FAILED, true);
+        }
 
         /* First WR, try to catch wakeup phase */
         if(lwmac->tx.wr_sent == 0) {
@@ -392,6 +416,7 @@ static bool _lwmac_tx_update(lwmac_t* lwmac)
         LOG_DEBUG("TX_STATE_SEND_DATA\n");
 
         gnrc_pktsnip_t* pkt = lwmac->tx.packet;
+        gnrc_pktsnip_t* pkt_payload;
 
         /* Enable Auto ACK again */
         netopt_enable_t autoack = NETOPT_ENABLE;
@@ -405,12 +430,23 @@ static bool _lwmac_tx_update(lwmac_t* lwmac)
         netopt_enable_t csma_enable = NETOPT_ENABLE;
 		lwmac->netdev2_driver->set(lwmac->netdev->dev, NETOPT_CSMA, &csma_enable, sizeof(csma_enable));
 
+        pkt_payload = pkt->next;
+
         /* Insert lwMAC header above NETIF header */
         lwmac_hdr_t hdr = {FRAMETYPE_DATA};
         pkt->next = gnrc_pktbuf_add(pkt->next, &hdr, sizeof(hdr), GNRC_NETTYPE_LWMAC);
+        if(pkt->next == NULL){
+            LOG_ERROR("Cannot allocate pktbuf of type FRAMETYPE_DATA\n");
+            lwmac->tx.packet->next = pkt_payload;
+            GOTO_TX_STATE(TX_STATE_FAILED, true);
+        }
 
         /* Send data */
-		lwmac->netdev->send(lwmac->netdev, pkt);
+        int res = lwmac->netdev->send(lwmac->netdev, pkt);
+        if(res < 0){
+            LOG_ERROR("Send data failed.");
+            GOTO_TX_STATE(TX_STATE_FAILED, true);
+        }
         _set_netdev_state(lwmac, NETOPT_STATE_TX);
 
         /* Packet has been released by netdev, so drop pointer */

--- a/sys/net/gnrc/link_layer/lwmac/tx_state_machine.c
+++ b/sys/net/gnrc/link_layer/lwmac/tx_state_machine.c
@@ -108,7 +108,7 @@ static bool _lwmac_tx_update(lwmac_t* lwmac)
 
         /* if found ongoing transmission,
          * quit this cycle for collision avoidance. */
-        if(_get_netdev_state(&lwmac) == NETOPT_STATE_RX) {
+        if(_get_netdev_state(lwmac) == NETOPT_STATE_RX){
             _queue_tx_packet(lwmac, lwmac->tx.packet);
             /* drop pointer so it wont be free'd */
             lwmac->tx.packet = NULL;
@@ -200,7 +200,7 @@ static bool _lwmac_tx_update(lwmac_t* lwmac)
 
         /* if found ongoing transmission,
          * quit this cycle for collision avoidance. */
-        if(_get_netdev_state(&lwmac) == NETOPT_STATE_RX) {
+        if(_get_netdev_state(lwmac) == NETOPT_STATE_RX) {
             _queue_tx_packet(lwmac, lwmac->tx.packet);
             /* drop pointer so it wont be free'd */
             lwmac->tx.packet = NULL;

--- a/sys/net/gnrc/link_layer/lwmac/tx_state_machine.c
+++ b/sys/net/gnrc/link_layer/lwmac/tx_state_machine.c
@@ -20,6 +20,7 @@
 #include <net/gnrc.h>
 #include <net/gnrc/lwmac/lwmac.h>
 #include <net/gnrc/lwmac/packet_queue.h>
+#include <random.h>
 
 #include "include/tx_state_machine.h"
 #include "include/timeout.h"
@@ -197,6 +198,10 @@ static bool _lwmac_tx_update(lwmac_t* lwmac)
         gnrc_netif_hdr_t *nethdr;
         //uint8_t* dst_addr = NULL;
         //int addr_len;
+
+        uint32_t random_backoff;
+        random_backoff = random_uint32_range(0, LWMAC_RANDOM_BEFORE_WR_US);
+        xtimer_usleep(random_backoff);
 
         /* if found ongoing transmission,
          * quit this cycle for collision avoidance. */


### PR DESCRIPTION
Here is my revisions for mostly tackling the WR collisions of Lw-MAC and other mirror issues. 
You can see the details in each commit. :-)

After some tests, I think Lw-MAC becomes more reliable after these adaptations. 

In short, I have made these major revisions:
1) use CSMA for sending the first WR for collision avoidance (the bad performance of Lw-MAC is mostly due to WR collisions of multi-senders);

1) make WR for broadcasting like WA, since I found that it is very hard to achieve WR collision avoidance among multi senders, if WR is unicasted to its receiver.

2) carry the phase-lock scheme based on WA. I inserted the phase information of the receiver into its WA, thus the sender can still infer the receiver's phase once it gets the replied WA. Also, this operation excludes the effect of using CSMA for sending WRs. 
